### PR TITLE
feat: multi-lineage matrix build with .dlib-versions.json

### DIFF
--- a/.dlib-versions.json
+++ b/.dlib-versions.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "./.dlib-versions.schema.json",
+  "versions": [
+    {
+      "image_tag": "dlib19",
+      "dlib_docker_tag": "19.24.9",
+      "dlib_docker_digest": "sha256:9cfeadcd58bb474783eec3471b19bcdde1c160b91b06e06df15ef6b5fc4fd95d",
+      "status": "active"
+    }
+  ]
+}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,74 @@
+name: Auto-release on .dlib-versions.json change
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.dlib-versions.json'
+
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    # Anti-recursion: skip if the push came from the release bot, and skip
+    # if the head-commit message starts with "Cut v" (defense in depth).
+    if: >-
+      github.actor != 'go-face-release-bot' &&
+      github.actor != 'github-actions[bot]' &&
+      !startsWith(github.event.head_commit.message, 'Cut v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check RELEASE_PAT is configured
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [ -z "${RELEASE_PAT:-}" ]; then
+            echo "::error::RELEASE_PAT secret is not configured. See README 'Automated releases' section."
+            exit 1
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          # PAT is required so the tag push triggers ci.yml. A push made with
+          # GITHUB_TOKEN deliberately does NOT trigger downstream workflows to
+          # prevent infinite loops.
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Bump patch and cut tag
+        run: |
+          set -euo pipefail
+
+          current=$(tr -d '[:space:]' < version.txt)
+          if [[ ! "$current" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version.txt does not match vN.N.N: '$current'"
+            exit 1
+          fi
+
+          IFS='.' read -r major minor patch <<< "${current#v}"
+          next="v${major}.${minor}.$((patch + 1))"
+          echo "Current: $current"
+          echo "Next:    $next"
+
+          # Abort if the tag already exists (e.g. a human cut it in parallel).
+          if git rev-parse --verify --quiet "refs/tags/$next" >/dev/null; then
+            echo "::warning::Tag $next already exists; skipping auto-release."
+            exit 0
+          fi
+
+          echo "$next" > version.txt
+          git config user.email 'go-face-release-bot@users.noreply.github.com'
+          git config user.name 'go-face-release-bot'
+          git add version.txt
+          git commit -m "Cut $next release"
+          git tag "$next"
+          git push origin main
+          git push origin "$next"
+
+          echo "Released $next."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,21 +32,41 @@ permissions:
 
 jobs:
 
+  setup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      matrix: ${{ steps.m.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build matrix from .dlib-versions.json
+        id: m
+        run: |
+          set -euo pipefail
+          matrix=$(jq -c '{include: [.versions[] | select(.status == "active")]}' .dlib-versions.json)
+          echo "Matrix: $matrix"
+          echo "matrix=$matrix" >>"$GITHUB_OUTPUT"
+
   static-check:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [setup]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     container:
-      image: ghcr.io/andriykalashnykov/dlib-docker:v19.24.4@sha256:91ea2d6b8b86c52069db6a554442862897fb53ba7365f691500dc0f06fe4578f
+      image: ghcr.io/andriykalashnykov/dlib-docker:${{ matrix.dlib_docker_tag }}@${{ matrix.dlib_docker_digest }}
+      # dlib-docker's default USER is a non-root appuser (uid 1000). CI
+      # needs root so actions/setup-go can install Go into
+      # /opt/hostedtoolcache and apt-get (if ever needed) can write to
+      # /var/lib/apt. This only affects the container runtime; the
+      # published image still runs as appuser by default.
+      options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-
-      - name: Update CA certificates
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends ca-certificates
-          rm -rf /var/lib/apt/lists/*
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -59,19 +79,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [static-check]
+    needs: [setup, static-check]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     container:
-      image: ghcr.io/andriykalashnykov/dlib-docker:v19.24.4@sha256:91ea2d6b8b86c52069db6a554442862897fb53ba7365f691500dc0f06fe4578f
+      image: ghcr.io/andriykalashnykov/dlib-docker:${{ matrix.dlib_docker_tag }}@${{ matrix.dlib_docker_digest }}
+      # dlib-docker's default USER is a non-root appuser (uid 1000). CI
+      # needs root so actions/setup-go can install Go into
+      # /opt/hostedtoolcache and apt-get (if ever needed) can write to
+      # /var/lib/apt. This only affects the container runtime; the
+      # published image still runs as appuser by default.
+      options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-
-      - name: Update CA certificates
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends ca-certificates
-          rm -rf /var/lib/apt/lists/*
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -84,19 +107,22 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [static-check]
+    needs: [setup, static-check]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     container:
-      image: ghcr.io/andriykalashnykov/dlib-docker:v19.24.4@sha256:91ea2d6b8b86c52069db6a554442862897fb53ba7365f691500dc0f06fe4578f
+      image: ghcr.io/andriykalashnykov/dlib-docker:${{ matrix.dlib_docker_tag }}@${{ matrix.dlib_docker_digest }}
+      # dlib-docker's default USER is a non-root appuser (uid 1000). CI
+      # needs root so actions/setup-go can install Go into
+      # /opt/hostedtoolcache and apt-get (if ever needed) can write to
+      # /var/lib/apt. This only affects the container runtime; the
+      # published image still runs as appuser by default.
+      options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-
-      - name: Update CA certificates
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends ca-certificates
-          rm -rf /var/lib/apt/lists/*
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -107,12 +133,15 @@ jobs:
         run: make test
 
   docker:
-    # Runs on every push. Step-level `if:` gates login/push/cosign to tag pushes,
-    # so multi-arch build regressions (arm64 cross-compile) and cosign-installer
-    # breakage are caught on the commit that introduced them, not on release day.
+    # Runs on every push. Step-level `if:` gates login/push/cosign to tag
+    # pushes so multi-arch build and cosign-installer regressions surface
+    # on the commit that introduced them, not on release day.
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [static-check, build, test]
+    needs: [setup, static-check, build, test]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     permissions:
       contents: read
       packages: write      # exercised only by the tag-gated push step
@@ -137,7 +166,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
-          images: ghcr.io/${{ env.OWNER_LC }}/go-face
+          images: ghcr.io/${{ env.OWNER_LC }}/go-face/${{ matrix.image_tag }}
           flavor: |
             latest=${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
@@ -146,10 +175,12 @@ jobs:
             type=semver,pattern={{major}}
           labels: |
             org.opencontainers.image.vendor=Andriy Kalashnykov - andriykalashnykov@gmail.com
-            org.opencontainers.image.title=Face recognition in Go with Dlib
-            org.opencontainers.image.description=Face recognition in Go with Dlib
+            org.opencontainers.image.title=Face recognition in Go with Dlib (${{ matrix.image_tag }})
+            org.opencontainers.image.description=Face recognition in Go with Dlib (${{ matrix.image_tag }})
             org.opencontainers.image.licenses=CC0
             org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.base.name=ghcr.io/andriykalashnykov/dlib-docker:${{ matrix.dlib_docker_tag }}
+            org.opencontainers.image.base.digest=${{ matrix.dlib_docker_digest }}
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/AndriyKalashnykov/go-face/main/README.md
             io.artifacthub.package.license=CC0
 
@@ -164,8 +195,10 @@ jobs:
           platforms: linux/amd64
           load: true
           tags: go-face:scan
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            BUILDER_IMAGE=ghcr.io/andriykalashnykov/dlib-docker:${{ matrix.dlib_docker_tag }}@${{ matrix.dlib_docker_digest }}
+          cache-from: type=gha,scope=${{ matrix.image_tag }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image_tag }}
 
       # ----------------------------------------------------------------
       # GATE 2: Trivy image scan — CRITICAL/HIGH blocking
@@ -184,10 +217,7 @@ jobs:
           skip-dirs: 'usr/local/go/src'
 
       # ----------------------------------------------------------------
-      # GATE 3: Smoke test — this image is a dev/testdata sandbox with
-      # `CMD tail -f /dev/null`, so the smoke test verifies that the Go
-      # toolchain, source files, and testdata baked into the image are
-      # actually present and runnable.
+      # GATE 3: Smoke test — dev/testdata sandbox container invariants.
       # ----------------------------------------------------------------
       - name: Smoke test
         run: |
@@ -196,12 +226,13 @@ jobs:
           docker run --rm go-face:scan /usr/local/go/bin/go version
           echo "→ smoke: source files and testdata present"
           docker run --rm go-face:scan bash -c 'test -f /app/face.go && test -f /app/facerec.cc && test -d /app/testdata'
-          echo "PASS: smoke test"
+          echo "PASS: smoke test for ${{ matrix.image_tag }}"
 
       # ----------------------------------------------------------------
       # Multi-arch build. Always runs (catches arm64 cross-compile
-      # regressions on the commit that introduced them). Push is tag-gated
-      # via the `push:` input, so non-tag pushes validate without publishing.
+      # regressions on the commit that introduced them). Push is tag-
+      # gated via the `push:` input, so non-tag pushes are validation-
+      # only.
       # ----------------------------------------------------------------
       - name: Log in to GHCR
         if: startsWith(github.ref, 'refs/tags/')
@@ -223,8 +254,10 @@ jobs:
           sbom: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            BUILDER_IMAGE=ghcr.io/andriykalashnykov/dlib-docker:${{ matrix.dlib_docker_tag }}@${{ matrix.dlib_docker_digest }}
+          cache-from: type=gha,scope=${{ matrix.image_tag }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image_tag }}
 
       # ----------------------------------------------------------------
       # GATE 5: cosign keyless OIDC signing — tag-only
@@ -249,7 +282,7 @@ jobs:
   ci-pass:
     if: always()
     runs-on: ubuntu-latest
-    needs: [static-check, build, test, docker]
+    needs: [setup, static-check, build, test, docker]
     steps:
       - name: Verify all required jobs passed
         run: |

--- a/.github/workflows/dlib-poll.yml
+++ b/.github/workflows/dlib-poll.yml
@@ -1,0 +1,117 @@
+name: Poll dlib-docker releases
+
+on:
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: dlib-poll
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  poll:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Discover new dlib-docker majors
+        id: discover
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Fetch every version of the dlib-docker package with its digest
+          # and tag list. The `name` field on a version is the manifest digest
+          # (e.g. sha256:...); `metadata.container.tags[]` is the list of tags
+          # pointing at that manifest.
+          gh api --paginate \
+            'users/andriykalashnykov/packages/container/dlib-docker/versions' \
+            --jq '.[] | {digest: .name, tags: (.metadata.container.tags // [])}' \
+            > /tmp/versions.jsonl
+
+          # Flatten into "tag digest" lines, keeping only clean semver tags.
+          jq -r 'select(.tags | length > 0) | .digest as $d | .tags[] | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) | "\(.)\t\($d)"' \
+            /tmp/versions.jsonl > /tmp/tags.tsv
+
+          if [ ! -s /tmp/tags.tsv ]; then
+            echo "No semver tags found on dlib-docker; nothing to do."
+            echo "added=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Existing majors in .dlib-versions.json (e.g. 19 20).
+          jq -r '.versions[].dlib_docker_tag' .dlib-versions.json \
+            | sed -n 's/^v\([0-9]\+\)\..*/\1/p' \
+            | sort -u > /tmp/known-majors.txt
+
+          # For every observed major, pick the highest semver tag.
+          # Output format: "MAJOR TAG DIGEST"
+          awk -F '\t' '{ split($1, v, "."); sub("v", "", v[1]); print v[1]"\t"$1"\t"$2 }' /tmp/tags.tsv \
+            | sort -t $'\t' -k1,1n -k2,2V \
+            | awk -F '\t' '{ best[$1]=$0 } END { for (k in best) print best[k] }' \
+            > /tmp/best-per-major.tsv
+
+          added=false
+          while IFS=$'\t' read -r major tag digest; do
+            if grep -qx "$major" /tmp/known-majors.txt; then
+              continue
+            fi
+            echo "New dlib-docker major detected: $major (tag=$tag digest=$digest)"
+            tmp=$(mktemp)
+            jq \
+              --arg image_tag "dlib$major" \
+              --arg tag "$tag" \
+              --arg digest "$digest" \
+              '.versions += [{
+                image_tag: $image_tag,
+                dlib_docker_tag: $tag,
+                dlib_docker_digest: $digest,
+                status: "active"
+              }]' \
+              .dlib-versions.json > "$tmp"
+            mv "$tmp" .dlib-versions.json
+            added=true
+          done < /tmp/best-per-major.tsv
+
+          if [ "$added" = true ]; then
+            echo "added=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "No new dlib-docker majors to add."
+            echo "added=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Open PR
+        if: steps.discover.outputs.added == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: auto/dlib-lineage
+          delete-branch: true
+          commit-message: 'chore(all): add new dlib-docker lineage'
+          title: 'chore(all): add new dlib-docker lineage'
+          body: |
+            New dlib-docker major version detected by `dlib-poll.yml`.
+            This PR adds an entry to `.dlib-versions.json` so the next
+            go-face release builds against the new lineage.
+
+            Once merged, `auto-release.yml` will cut the next patch
+            release automatically.
+          labels: |
+            dependencies
+            automerge
+
+      - name: Enable auto-merge
+        if: steps.discover.outputs.added == 'true' && steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge --auto --squash "$PR"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ make ci-run       # Run GitHub Actions workflow locally via act
 | `GO_VERSION` | derived from `go.mod` | Go toolchain version |
 | `GOLANGCI_VERSION` | `2.11.4` | golangci-lint version |
 | `HADOLINT_VERSION` | `2.14.0` | hadolint version |
-| `GOSEC_VERSION` | `2.22.12` | gosec version |
+| `GOSEC_VERSION` | `2.25.0` | gosec version |
 | `GOVULNCHECK_VERSION` | `1.1.4` | govulncheck version |
 | `ACT_VERSION` | `0.2.87` | act version |
 | `NVM_VERSION` | `0.40.4` | nvm version (bootstraps Node for Renovate) |
@@ -47,6 +47,12 @@ make ci-run       # Run GitHub Actions workflow locally via act
 
 All tool versions have `# renovate:` inline comments; Renovate tracks them via
 the generic `customManagers` regex in `renovate.json`.
+
+The **source of truth for supported dlib-docker lineages** is
+`.dlib-versions.json`. Each entry pins a `dlib_docker_tag` + `dlib_docker_digest`
+pair; Renovate tracks those pairs via a second `customManagers` regex and
+`dlib-poll.yml` discovers new major versions. The `image_tag` (e.g. `dlib19`)
+becomes the GHCR sub-package suffix: `ghcr.io/andriykalashnykov/go-face/dlib19`.
 
 ## Project Structure
 
@@ -60,10 +66,12 @@ the generic `customManagers` regex in `renovate.json`.
 ├── doc.go               # Package documentation
 ├── face_test.go         # Tests
 ├── example_test.go      # Example tests
-├── Dockerfile           # Multi-arch Docker image build
+├── Dockerfile           # Multi-arch Docker image build (ARG BUILDER_IMAGE)
+├── .dockerignore        # Build context exclusions
+├── .dlib-versions.json  # Source of truth for supported dlib-docker lineages
 ├── .hadolint.yaml       # Hadolint configuration for Dockerfile linting
 ├── .nvmrc               # Node version (for Renovate local runs)
-├── testdata/            # Test models and images (cloned separately)
+├── testdata/            # Test models and images (committed)
 └── .github/workflows/   # CI/CD pipelines
 ```
 
@@ -75,14 +83,16 @@ the generic `customManagers` regex in `renovate.json`.
 - **Concurrency**: cancel-in-progress enabled
 - **Permissions**: `contents: read` at workflow level (minimal)
 - **Paths ignored**: `**/*.md`, `docs/**`, `.gitignore`, `.claude/**`, `.idea/**`, `LICENSE`, `version.txt`
+- **Matrix**: every lineage in `.dlib-versions.json` with `status: active` runs in parallel through `static-check`, `build`, `test`, and `docker` (`fail-fast: false`).
 
 | Job | Runs on | Description |
 |-----|---------|-------------|
-| `static-check` | ubuntu-latest (dlib container) | `make static-check` (format-check, lint, vulncheck, sec) |
-| `build` | ubuntu-latest (dlib container) | `make build`, needs `static-check` |
-| `test` | ubuntu-latest (dlib container) | `make test`, needs `static-check` |
-| `docker` | ubuntu-latest (every push) | Hardened image pipeline: build-for-scan, Trivy image scan, smoke test, multi-arch build (push tag-gated), cosign keyless signing (tag-gated) |
-| `ci-pass` | ubuntu-latest (`if: always()`) | Aggregator gate — fails if any required job failed or was cancelled |
+| `setup` | ubuntu-latest | Reads `.dlib-versions.json`, emits the matrix for downstream jobs |
+| `static-check` | ubuntu-latest (dlib container, one per lineage) | `make static-check` (format-check, lint, vulncheck, sec) |
+| `build` | ubuntu-latest (dlib container, one per lineage) | `make build`, needs `static-check` |
+| `test` | ubuntu-latest (dlib container, one per lineage) | `make test`, needs `static-check` |
+| `docker` | ubuntu-latest (bare, one per lineage) | Hardened image pipeline. Publishes to `ghcr.io/.../go-face/${{ matrix.image_tag }}` on tag push. |
+| `ci-pass` | ubuntu-latest (`if: always()`) | Aggregator gate — fails if any matrix expansion of any job failed or was cancelled |
 
 The `docker` job runs on **every push**, not just tags. Login, push, and
 cosign signing are gated at step-level via `if: startsWith(github.ref, 'refs/tags/')`
@@ -92,11 +102,35 @@ that introduced them, not on release day. Permissions: `contents: read` +
 GHCR auth uses the built-in `GITHUB_TOKEN`. Buildkit in-manifest attestations
 are disabled (`provenance: false`, `sbom: false`) so the GHCR "OS / Arch" tab
 renders — cosign keyless signing provides supply-chain verification instead.
+The `BUILDER_IMAGE` build-arg and the base-image OCI labels come from the
+matrix entry, so each published image records exactly which `dlib-docker`
+tag+digest it was built against.
 
-Pre-push gates: (1) build single-arch for scan, (2) Trivy image scan
-`CRITICAL`/`HIGH` blocking, (3) smoke test (Go toolchain + source + testdata
-invariants), (4) multi-arch build with conditional push, (5) cosign keyless
-signing tag-only. See README "Pre-push image hardening" for details.
+Pre-push gates (per matrix entry): (1) build single-arch for scan, (2) Trivy
+image scan `CRITICAL`/`HIGH` blocking, (3) smoke test (Go toolchain + source
++ testdata invariants), (4) multi-arch build with conditional push, (5)
+cosign keyless signing tag-only. See README "Pre-push image hardening" for
+details.
+
+### dlib-poll.yml
+
+- **Triggers**: daily cron (`0 6 * * *`), `workflow_dispatch`
+- **Permissions**: `contents: write`, `pull-requests: write`
+- Queries `ghcr.io/andriykalashnykov/dlib-docker` for published tags, groups
+  them by major, and opens an auto-merging PR that adds any new majors to
+  `.dlib-versions.json`. New patches within an already-tracked major are
+  handled by Renovate, not this poller.
+
+### auto-release.yml
+
+- **Triggers**: `push` to `main` touching `.dlib-versions.json`
+- **Permissions**: `contents: read` at job level; the actual push uses a PAT
+- Bumps `version.txt` patch (e.g., `v0.1.0` → `v0.1.1`), commits as
+  `Cut vX.Y.Z release`, creates the tag, pushes main + tag.
+  Uses the `RELEASE_PAT` secret because `GITHUB_TOKEN`-authored tag pushes
+  deliberately do not trigger downstream workflows. Anti-recursion: skips
+  commits by `go-face-release-bot` or `github-actions[bot]`, and skips
+  commits whose message starts with `Cut v`.
 
 ### cleanup-runs.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE="ghcr.io/andriykalashnykov/dlib-docker:v19.24.4@sha256:91ea2d6b8b86c52069db6a554442862897fb53ba7365f691500dc0f06fe4578f"
+ARG BUILDER_IMAGE="ghcr.io/andriykalashnykov/dlib-docker:19.24.9@sha256:9cfeadcd58bb474783eec3471b19bcdde1c160b91b06e06df15ef6b5fc4fd95d"
 
 FROM ${BUILDER_IMAGE} AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ ARG BUILDER_IMAGE="ghcr.io/andriykalashnykov/dlib-docker:19.24.9@sha256:9cfeadcd
 
 FROM ${BUILDER_IMAGE} AS builder
 
+# dlib-docker's default USER is appuser (uid 1000); switch to root for
+# build-time steps (apt, Go install to /usr/local). A later `USER` at
+# the bottom of this file drops the final-stage runtime back to nobody.
+USER root
+
 ARG DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3008

--- a/README.md
+++ b/README.md
@@ -175,27 +175,49 @@ Run `make help` to see all available targets.
 GitHub Actions runs on every push to `main`, tags (`v*`), and pull requests.
 The workflow is also `workflow_call`-able for downstream reuse.
 
+### Per-lineage matrix
+
+go-face publishes one container image **per supported dlib-docker major
+version**. The set of supported lineages is declared in
+[`.dlib-versions.json`](./.dlib-versions.json) and fans out across the entire
+CI pipeline — `static-check`, `build`, `test`, and `docker` each run once per
+active entry, in parallel. A single tag push produces one published image per
+lineage, and each lineage ends up in its own GHCR sub-package:
+
+| Lineage | dlib-docker base | Image |
+|---------|------------------|-------|
+| `dlib19` | `dlib-docker:v19.24.4` | `ghcr.io/andriykalashnykov/go-face/dlib19` |
+
+Adding a new lineage is a one-line change to `.dlib-versions.json` — or you
+can let the automation do it (see "Automated releases" below).
+
+### Jobs
+
 | Job | Triggers | Description |
 |-----|----------|-------------|
-| `static-check` | push, PR, tags | Runs `make static-check` (format-check, lint, vulncheck, sec) inside the dlib container |
-| `build` | push, PR, tags | Runs `make build` after `static-check` passes |
-| `test` | push, PR, tags | Runs `make test` after `static-check` passes |
-| `docker` | tags only | Builds and pushes multi-arch Docker images (`linux/amd64`, `linux/arm64`) to GHCR |
-| `ci-pass` | always | Aggregator that fails if any required job failed or was cancelled |
+| `setup` | push, PR, tags | Reads `.dlib-versions.json` and emits the matrix used by downstream jobs |
+| `static-check` | push, PR, tags | `make static-check` (format-check, lint, vulncheck, sec), once per active dlib lineage |
+| `build` | push, PR, tags | `make build`, once per active dlib lineage |
+| `test` | push, PR, tags | `make test`, once per active dlib lineage |
+| `docker` | push, PR, tags | Hardened image pipeline, once per active dlib lineage. Builds and cosign-signs on tag pushes; validation-only on non-tag pushes |
+| `ci-pass` | always | Aggregator gate. Fails if **any** matrix expansion of **any** job failed or was cancelled |
 
 A separate [cleanup workflow](.github/workflows/cleanup-runs.yml) removes old
 workflow runs and caches weekly.
 
 The `docker` job authenticates to GHCR using the built-in `GITHUB_TOKEN` — no
-additional secrets are required. [Renovate](https://docs.renovatebot.com/)
-keeps dependencies up to date with platform automerge enabled.
+additional secrets are required for publishing. [Renovate](https://docs.renovatebot.com/)
+keeps dependencies (including `dlib-docker` tag+digest pairs in
+`.dlib-versions.json`) up to date with platform automerge enabled.
 
 ### Pre-push image hardening
 
 The `docker` job runs on **every push** (not just tags) so multi-arch build
 regressions and cosign-installer breakage surface on the commit that introduced
 them. Login, push, and cosign signing are gated at step-level to tag pushes.
-All gates must pass before any image is published:
+Every matrix entry goes through the same five gates — one bad lineage does not
+block the others (`fail-fast: false`), but `ci-pass` still fails the run so no
+image is published partially:
 
 | # | Gate | Catches | Tool |
 |---|------|---------|------|
@@ -203,21 +225,73 @@ All gates must pass before any image is published:
 | 2 | Trivy image scan (`CRITICAL`/`HIGH` blocking) | CVEs in the `dlib-docker` base image, OS packages, and build layers | `aquasecurity/trivy-action` with `image-ref:` |
 | 3 | Smoke test | Image boots, Go toolchain runs, source files and `testdata/` are present | `docker run` invariant checks |
 | 4 | Multi-arch build + conditional push | `linux/arm64` cross-compile regressions; publishes both platforms on tag pushes | `docker/build-push-action` |
-| 5 | Cosign keyless OIDC signing | Sigstore signature on the manifest digest (tag-only, Phase 2) | `sigstore/cosign-installer` + `cosign sign` |
+| 5 | Cosign keyless OIDC signing | Sigstore signature on the manifest digest (tag-only) | `sigstore/cosign-installer` + `cosign sign` |
 
 Buildkit in-manifest attestations (`provenance` + `sbom`) are deliberately
 **disabled** so the OCI image index stays free of `unknown/unknown` platform
 entries — that lets the GHCR Packages UI render the "OS / Arch" tab for the
 multi-arch manifest. Cosign keyless signing still provides the Sigstore
-signature for supply-chain verification.
+signature for supply-chain verification. The base image name and digest are
+recorded in each published manifest as
+`org.opencontainers.image.base.name` and `org.opencontainers.image.base.digest`
+OCI labels so consumers can see exactly which `dlib-docker` build produced
+a given image.
 
 Verify a published image's signature:
 
 ```bash
-cosign verify ghcr.io/andriykalashnykov/go-face:<tag> \
+cosign verify ghcr.io/andriykalashnykov/go-face/dlib19:<tag> \
   --certificate-identity-regexp 'https://github\.com/AndriyKalashnykov/go-face/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
+
+Replace `dlib19` with whichever lineage you are pulling.
+
+### Automated releases
+
+New dlib-docker releases flow into new go-face releases automatically. There
+are three workflows involved:
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| [`dlib-poll.yml`](.github/workflows/dlib-poll.yml) | Daily cron + `workflow_dispatch` | Queries the `dlib-docker` GHCR package, compares the set of observed major versions against `.dlib-versions.json`, and opens an auto-merging PR that adds any new majors. |
+| `renovate` (SaaS) | On its own schedule | Bumps the `dlib_docker_tag` + `dlib_docker_digest` pair of **existing** lineages when `dlib-docker` repushes an existing tag with a new digest or ships a new patch within an existing major line. |
+| [`auto-release.yml`](.github/workflows/auto-release.yml) | `push` to `main` touching `.dlib-versions.json` | Bumps the **patch** in `version.txt`, commits as `Cut vX.Y.Z release`, creates the matching git tag, and pushes both. The tag push retriggers `ci.yml`, which matrix-builds and cosign-signs every active lineage. |
+
+Together:
+
+1. `dlib-docker` ships a new version →
+2. Renovate (for digest bumps) or `dlib-poll` (for new majors) opens a PR →
+3. CI runs against the proposed update; auto-merge squashes it into `main` on green →
+4. `auto-release` bumps `version.txt` patch, cuts the next tag, pushes →
+5. `ci.yml` fans out across every active lineage, publishes, and cosign-signs →
+6. Consumers pulling `ghcr.io/andriykalashnykov/go-face/dlib19:<latest>` get the new build.
+
+Minor and major version bumps stay **manual** — when you change go-face's own
+code (not just the base image), use `make release` to cut a tag directly.
+
+#### Required secret: `RELEASE_PAT`
+
+`auto-release.yml` needs a Personal Access Token to push tags, because tags
+pushed with `GITHUB_TOKEN` deliberately do not trigger downstream workflows.
+Without `RELEASE_PAT`, the new tag would land in the repo but `ci.yml` would
+not fire against it.
+
+Create a **classic PAT** with these scopes:
+
+- `contents: write` — push commits and tags
+- `workflow` — allows the token to push changes under `.github/workflows/`
+  (not strictly required by `auto-release.yml` today, but future-proofs
+  against workflow edits needing to ship alongside a release)
+
+Add it at **Settings → Secrets and variables → Actions → New repository
+secret** with the name `RELEASE_PAT`. The workflow fails fast with a clear
+error message if the secret is missing.
+
+> A fine-grained PAT scoped to this single repo also works, with the same
+> permissions: **Contents: Read and write** and **Workflows: Read and write**.
+> A GitHub App installation token is the production-grade alternative if you
+> want to avoid PAT rotation, but requires more setup.
 
 ## Models
 

--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,16 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)( versioning=(?<versioning>[^\\s]+))?\\n[A-Z_]+\\s*:=\\s*(?<currentValue>[^\\s]+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Track dlib-docker tag and digest pairs in .dlib-versions.json",
+      "managerFilePatterns": ["/^\\.dlib-versions\\.json$/"],
+      "matchStrings": [
+        "\"dlib_docker_tag\":\\s*\"(?<currentValue>[^\"]+)\",\\s*\"dlib_docker_digest\":\\s*\"(?<currentDigest>sha256:[a-f0-9]+)\""
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/andriykalashnykov/dlib-docker"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

Parameterize the Docker build by dlib-docker major version so each tagged release publishes one hardened go-face image per supported dlib lineage into its own GHCR sub-package.

**Draft / verification-only push.** The point of this branch is to verify the new matrix+automation shape runs cleanly on real GitHub Actions runners before merging. Do not merge until CI is green and the design has been reviewed.

## Architecture

- **`.dlib-versions.json`** — source of truth for supported dlib-docker majors. Each entry pins a tag+digest pair and a `dlib<major>` image-tag suffix for the GHCR sub-package.
- **`ci.yml`** — new `setup` job emits the matrix; `static-check` / `build` / `test` / `docker` all fan out with `fail-fast: false`. Container jobs use `options: --user root` to override dlib-docker's non-root default so `actions/setup-go` can install Go.
- **`dlib-poll.yml`** — daily cron. Discovers new dlib-docker majors and opens auto-merging PRs adding them to `.dlib-versions.json`.
- **`auto-release.yml`** — on push to main touching `.dlib-versions.json`, bumps `version.txt` patch, cuts the next git tag, pushes via `RELEASE_PAT`.
- **Renovate** — new `customManagers` regex tracks tag+digest pairs in `.dlib-versions.json`.

## What needs to pass on this PR

1. `setup` job parses `.dlib-versions.json` and emits matrix
2. `static-check (dlib19)`, `build (dlib19)`, `test (dlib19)` all succeed against `dlib-docker:19.24.9@sha256:9cfeadcd…`
3. `docker (dlib19)` runs through gates 1–4 (build for scan, Trivy, smoke test, multi-arch build — push:false on non-tag, cosign skipped)
4. `ci-pass` green

## Deferred (not required for this PR to merge)

- `RELEASE_PAT` secret setup — required before the first auto-release flow works, not required for this PR
- First activation of `dlib-poll.yml` (can be triggered manually once merged via `workflow_dispatch`)

## Test plan

- [ ] `setup` job parses `.dlib-versions.json` successfully
- [ ] `static-check (dlib19)` passes — `make static-check` runs lint + vulncheck + sec + format-check
- [ ] `build (dlib19)` passes — `make build` cgo-compiles
- [ ] `test (dlib19)` passes — go test against live dlib 19.24.9
- [ ] `docker (dlib19)` gates 1–3 pass (build for scan, Trivy scan, smoke test)
- [ ] `ci-pass` green
- [ ] No warnings in run logs (`warn`, `deprecated`, `future-incompat` grep)