### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,8 @@ ci: deps static-check test build
 release:
 	@bash -c 'read -p "New tag (current: $(CURRENTTAG)): " newtag && \
 		echo "$$newtag" | grep -qE "^v[0-9]+\.[0-9]+\.[0-9]+$$" || { echo "Error: Tag must match vN.N.N"; exit 1; } && \
+		{ ! git rev-parse -q --verify "refs/tags/$$newtag" >/dev/null 2>&1 || { echo "ERROR: tag $$newtag already exists locally. Pick a new version or delete it: git tag -d $$newtag"; exit 1; }; } && \
+		{ ! git ls-remote --exit-code --tags origin "refs/tags/$$newtag" >/dev/null 2>&1 || { echo "ERROR: tag $$newtag already exists on origin. Pick a new version."; exit 1; }; } && \
 		echo -n "Create and push $$newtag? [y/N] " && read ans && [ "$${ans:-N}" = y ] && \
 		echo $$newtag > ./version.txt && \
 		git add version.txt && \


### PR DESCRIPTION
The `release` recipe wrote `version.txt` and ran `git commit` before `git tag`, with no check that the target tag was free. Re-running with an already-published tag would land a dangling "Cut vX release" commit while `git tag` aborted — a half-published release (Makefile Safety Check #16).

**Fix:** add a fail-before-mutation guard right after semver validation and before the confirm prompt — reject the tag if it exists locally (`git rev-parse --verify`) or on origin (`git ls-remote --tags`). Preserves the recipe's `&&`-chained `bash -c` style; no happy-path change.

Verified: guard fires before any commit/tag against an existing tag (`v0.1.4`), leaving `git status` clean; `make -n release` parses cleanly.