### PR TITLE
fix(deps): bump go directive to 1.26.4 to clear stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/AndriyKalashnykov/go-face
 
-go 1.26.2
+go 1.26.4


### PR DESCRIPTION
fix(deps): bump go directive to 1.26.4 to clear stdlib CVEs

Trivy image scan (docker job, both dlib19/dlib20 matrix legs) failed on
6 HIGH Go stdlib CVEs baked into the Go toolchain binaries shipped in
the image (installed v1.26.2): CVE-2026-27145 (crypto/x509 DoS,
fixed 1.26.4), CVE-2026-33811, CVE-2026-33814, CVE-2026-39820,
CVE-2026-39836, CVE-2026-42499 (all fixed <= 1.26.3).

The Dockerfile extracts GO_VER from go.mod's `go` directive to pick the
Go download; CI setup-go also reads go-version-file: go.mod. So the
single-source fix is bumping the directive 1.26.2 -> 1.26.4, which
pulls a patched toolchain in both the image and CI.

Verified locally: image rebuilt and `trivy image --severity
CRITICAL,HIGH --ignore-unfixed --skip-dirs usr/local/go/src` exits 0
(was 6 HIGH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)